### PR TITLE
feat: Refactor AnimalApiService and PlayerService to use WebClient.builder() directly

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.springframework.boot") version "4.0.0-SNAPSHOT"
+    id("org.springframework.boot") version "4.0.0-restructure-SNAPSHOT"
     id("io.spring.dependency-management") version "1.1.7"
 }
 
@@ -32,11 +32,11 @@ repositories {
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-mongodb-reactive")
-    implementation("org.springframework.boot:spring-boot-starter-webclient")
     implementation("com.discord4j:discord4j-core:$discord4jVersion")
     implementation("org.apache.commons:commons-lang3:$commonsLang3Version")
     implementation("org.apache.commons:commons-text:$commonsTextVersion")
     implementation("com.github.ben-manes.caffeine:caffeine:$caffeineVersion")
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
     compileOnly("org.projectlombok:lombok")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     developmentOnly("org.springframework.boot:spring-boot-docker-compose")

--- a/src/main/java/dev/lunqia/usobot/animal/AnimalApiService.java
+++ b/src/main/java/dev/lunqia/usobot/animal/AnimalApiService.java
@@ -1,6 +1,6 @@
 package dev.lunqia.usobot.animal;
 
-import java.util.Objects;
+import dev.lunqia.usobot.utils.HttpUtils;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
@@ -12,11 +12,11 @@ import reactor.core.publisher.Mono;
 public class AnimalApiService {
   private final WebClient webClient;
 
-  public AnimalApiService(
-      WebClient.Builder webClientBuilder, AnimalApiProperties animalApiProperties) {
-    this.webClient =
-        webClientBuilder
+  public AnimalApiService(AnimalApiProperties animalApiProperties) {
+    webClient =
+        WebClient.builder()
             .baseUrl(animalApiProperties.getBaseUrl())
+            .defaultHeader(HttpHeaders.USER_AGENT, HttpUtils.USER_AGENT)
             .defaultHeader(HttpHeaders.CONTENT_TYPE, "application/json")
             .build();
   }
@@ -27,8 +27,7 @@ public class AnimalApiService {
         .uri("/img/{animal}", animalType.getApiName())
         .retrieve()
         .bodyToMono(AnimalResponse.class)
-        .map(AnimalResponse::image)
-        .filter(Objects::nonNull);
+        .map(AnimalResponse::image);
   }
 
   public Mono<String> getRandomAnimalFact(AnimalType animalType) {
@@ -37,8 +36,7 @@ public class AnimalApiService {
         .uri("/fact/{animal}", animalType.getApiName())
         .retrieve()
         .bodyToMono(AnimalResponse.class)
-        .map(AnimalResponse::fact)
-        .filter(Objects::nonNull);
+        .map(AnimalResponse::fact);
   }
 
   public Mono<AnimalResponse> getRandomAnimalImageAndFact(AnimalType animalType) {

--- a/src/main/java/dev/lunqia/usobot/overwatch2/player/PlayerService.java
+++ b/src/main/java/dev/lunqia/usobot/overwatch2/player/PlayerService.java
@@ -24,12 +24,9 @@ public class PlayerService {
   private final OverfastApiCache overfastApiCache;
   private final ObjectMapper objectMapper;
 
-  public PlayerService(
-      WebClient.Builder webClientBuilder,
-      OverfastApiCache overfastApiCache,
-      ObjectMapper objectMapper) {
-    this.webClient =
-        webClientBuilder
+  public PlayerService(OverfastApiCache overfastApiCache, ObjectMapper objectMapper) {
+    webClient =
+        WebClient.builder()
             .baseUrl(OverfastApiEndpointType.BASE_URL)
             .defaultHeader(HttpHeaders.USER_AGENT, HttpUtils.USER_AGENT)
             .defaultHeaders(


### PR DESCRIPTION
## Summary by Sourcery

Refactor AnimalApiService and PlayerService to instantiate WebClient directly via WebClient.builder(), removing injected WebClient.Builder and unnecessary null filters, and update the build configuration to use spring-boot-starter-webflux and bump the Spring Boot plugin version.

Enhancements:
- Refactor AnimalApiService to use WebClient.builder() directly and remove redundant null filtering on responses
- Refactor PlayerService to instantiate WebClient via WebClient.builder() and drop WebClient.Builder injection

Build:
- Bump Spring Boot plugin version to 4.0.0-restructure-SNAPSHOT
- Replace spring-boot-starter-webclient with spring-boot-starter-webflux dependency