### PR TITLE
fix: Update GitHub Release action to use release metadata

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,6 @@ jobs:
           name: uso-bot
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@6cbd405e2c4e67a21c47fa9e383d020e4e28b836
+        uses: softprops/action-gh-release@v2
         with:
           files: uso-bot.jar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,11 @@ jobs:
           name: uso-bot
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@6cbd405e2c4e67a21c47fa9e383d020e4e28b836
         with:
           files: uso-bot.jar
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: v${{ github.run_number }}
+          RELEASE_NAME: Release v${{ github.run_number }}
+          RELEASE_BODY: Automated release of uso-bot version v${{ github.run_number }}'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "dev.lunqia"
-version = "1.0.0-SNAPSHOT"
+version = "1.0.1-SNAPSHOT"
 description = "uso-bot"
 
 val discord4jVersion: String by project

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.springframework.boot") version "4.0.0-SNAPSHOT"
+    id("org.springframework.boot") version "4.0.0-restructure-SNAPSHOT"
     id("io.spring.dependency-management") version "1.1.7"
 }
 
@@ -32,11 +32,11 @@ repositories {
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-mongodb-reactive")
-    implementation("org.springframework.boot:spring-boot-starter-webclient")
     implementation("com.discord4j:discord4j-core:$discord4jVersion")
     implementation("org.apache.commons:commons-lang3:$commonsLang3Version")
     implementation("org.apache.commons:commons-text:$commonsTextVersion")
     implementation("com.github.ben-manes.caffeine:caffeine:$caffeineVersion")
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
     compileOnly("org.projectlombok:lombok")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     developmentOnly("org.springframework.boot:spring-boot-docker-compose")

--- a/src/main/java/dev/lunqia/usobot/animal/AnimalApiService.java
+++ b/src/main/java/dev/lunqia/usobot/animal/AnimalApiService.java
@@ -1,6 +1,6 @@
 package dev.lunqia.usobot.animal;
 
-import java.util.Objects;
+import dev.lunqia.usobot.utils.HttpUtils;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
@@ -12,11 +12,11 @@ import reactor.core.publisher.Mono;
 public class AnimalApiService {
   private final WebClient webClient;
 
-  public AnimalApiService(
-      WebClient.Builder webClientBuilder, AnimalApiProperties animalApiProperties) {
-    this.webClient =
-        webClientBuilder
+  public AnimalApiService(AnimalApiProperties animalApiProperties) {
+    webClient =
+        WebClient.builder()
             .baseUrl(animalApiProperties.getBaseUrl())
+            .defaultHeader(HttpHeaders.USER_AGENT, HttpUtils.USER_AGENT)
             .defaultHeader(HttpHeaders.CONTENT_TYPE, "application/json")
             .build();
   }
@@ -27,8 +27,7 @@ public class AnimalApiService {
         .uri("/img/{animal}", animalType.getApiName())
         .retrieve()
         .bodyToMono(AnimalResponse.class)
-        .map(AnimalResponse::image)
-        .filter(Objects::nonNull);
+        .map(AnimalResponse::image);
   }
 
   public Mono<String> getRandomAnimalFact(AnimalType animalType) {
@@ -37,8 +36,7 @@ public class AnimalApiService {
         .uri("/fact/{animal}", animalType.getApiName())
         .retrieve()
         .bodyToMono(AnimalResponse.class)
-        .map(AnimalResponse::fact)
-        .filter(Objects::nonNull);
+        .map(AnimalResponse::fact);
   }
 
   public Mono<AnimalResponse> getRandomAnimalImageAndFact(AnimalType animalType) {

--- a/src/main/java/dev/lunqia/usobot/overwatch2/player/PlayerService.java
+++ b/src/main/java/dev/lunqia/usobot/overwatch2/player/PlayerService.java
@@ -24,12 +24,9 @@ public class PlayerService {
   private final OverfastApiCache overfastApiCache;
   private final ObjectMapper objectMapper;
 
-  public PlayerService(
-      WebClient.Builder webClientBuilder,
-      OverfastApiCache overfastApiCache,
-      ObjectMapper objectMapper) {
-    this.webClient =
-        webClientBuilder
+  public PlayerService(OverfastApiCache overfastApiCache, ObjectMapper objectMapper) {
+    webClient =
+        WebClient.builder()
             .baseUrl(OverfastApiEndpointType.BASE_URL)
             .defaultHeader(HttpHeaders.USER_AGENT, HttpUtils.USER_AGENT)
             .defaultHeaders(


### PR DESCRIPTION
## Summary by Sourcery

Streamline WebClient setup, adjust dependencies and plugin versions, and upgrade the GitHub Release action to v2

Enhancements:
- Simplify WebClient instantiation in AnimalApiService and PlayerService by removing builder injection and adding a default USER_AGENT header
- Remove redundant null filters on response mappings in AnimalApiService

Build:
- Bump Spring Boot plugin to 4.0.0-restructure-SNAPSHOT and swap spring-boot-starter-webclient for spring-boot-starter-webflux

CI:
- Update softprops/action-gh-release in the build workflow to use version v2